### PR TITLE
Fix not working when no filter options

### DIFF
--- a/csviewer.go
+++ b/csviewer.go
@@ -205,6 +205,10 @@ func (v *Csviewer) Print(opt *sortOption) {
 }
 
 func (v *Csviewer) filter(rowMap map[string]interface{}) bool {
+	if len(v.filters) == 0 {
+		return true
+	}
+
 	values := make(map[string]interface{}, 0)
 
 	for key, val := range rowMap {


### PR DESCRIPTION
Sorry...
#5 is not working when no filter options.
Fix it. Please review it.

```console
$ ./csviewer -p _example/example.csv
+-----+-------+-----------------+-----------+--------+
| ID  | NAME  |      MAIL       |   PHONE   | ADRESS |
+-----+-------+-----------------+-----------+--------+
|   1 | a     | aaaa@hoge.fuga  |    123456 | 111111 |
|   2 | b     | bbb@hoge.fuga   |     12345 |        |
|   3 | c     |                 |           |  22222 |
|   5 | d     | ddd@fuga.hgoe   | 123456789 |        |
|  10 | e     | eeeee@fuga.hgoe |    654321 |        |
| 222 | asdfg | asdfg@fuga.hgoe | 987654321 |        |
+-----+-------+-----------------+-----------+--------+

$ ./csviewer -p _example/example.csv -f "id > 2 && id <= 10"
+----+------+-----------------+-----------+--------+
| ID | NAME |      MAIL       |   PHONE   | ADRESS |
+----+------+-----------------+-----------+--------+
|  3 | c    |                 |           |  22222 |
|  5 | d    | ddd@fuga.hgoe   | 123456789 |        |
| 10 | e    | eeeee@fuga.hgoe |    654321 |        |
+----+------+-----------------+-----------+--------+
```